### PR TITLE
Add documentation and templates (Mission Control, prompt mall, Morning Brief, Weekly Digest, QA checklist, PR plan)

### DIFF
--- a/docs/morning-brief.md
+++ b/docs/morning-brief.md
@@ -1,0 +1,18 @@
+# Morning Brief – Mall
+
+Denna dagliga brief sammanfattar aktuell status och planering. Fyll i varje sektion kortfattat.
+
+## Datum
+Skriv aktuellt datum (ÅÅÅÅ‑MM‑DD).
+
+## Lägesrapport
+- Vad har gjorts sedan senaste briefen? Summera arbetet och eventuella framsteg.
+
+## Plan för idag
+- Vilka uppgifter ska prioriteras under dagen? Lista kort vad som ska göras.
+
+## Blockerare & hinder
+- Finns det något som hindrar arbetet? Behöver du hjälp eller resurser?
+
+## Assistentens status
+- Kort notering från agenten om arbetsbelastning och eventuella behov (t.ex. mer information, extra access).

--- a/docs/pr_plan.md
+++ b/docs/pr_plan.md
@@ -1,0 +1,13 @@
+# PR ‑plan: Dokumentation och mallar
+
+1. **Syfte:** Lägga till dokumentation och mallar för processerna “Mission Control”, standardmallar för uppdrag, Morning Brief, Weekly Digest och QA‑checklista i repositoryt.
+2. **Branch:** Denna PR skapas från en separat dokumentationsbranch (`docs-templates`) för att undvika förändringar i huvudbranschen.
+3. **Filer som inkluderas:**
+   - `docs/mission-control.md` – Kanban struktur med kolumnerna Backlog, Doing, Review, Done samt WIP regler och definition of done.
+   - `docs/prompt-mallar.md` – Standardmall för uppdrag (promptmall) med rubriker för mål, förutsättningar, leverans och risker.
+   - `docs/morning-brief.md` – Mall för daglig morgonbrief med sektioner för datum, lägesrapport, plan, blockerare och assistentens status.
+   - `docs/weekly-digest.md` – Mall för veckovis sammanfattning med highlights, uppgiftsstatus, risker och nästa veckas fokus.
+   - `docs/qa-checklista.md` – QA checklista för pull requests och förändringar.
+   - `docs/pr_plan.md` – Denna plan för PR:n för spårbarhet.
+4. **Commit meddelande:** “Add documentation and templates (Mission Control, prompt mall, Morning Brief, Weekly Digest, QA checklist, PR plan)”
+5. **Pull request:** Skapa en PR mot huvudbranschen och länka till relaterade issues. Inkludera sektionerna What/Why/Verify i beskrivningen. `Verify` ska notera att PR:n endast innehåller dokumentation och inte påverkar runtime.

--- a/docs/prompt-mallar.md
+++ b/docs/prompt-mallar.md
@@ -1,0 +1,19 @@
+# Standardmall för uppdrag (Promptmall)
+
+Denna mall används för att beskriva uppdrag som delegeras till agenten. Anpassa vid behov beroende på uppgiftens natur.
+
+## Rubriker i mallen
+
+- **Syfte/mål** – Vad ska uppnås? Beskriv det önskade resultatet tydligt.
+- **Förutsättningar** – Vilka resurser, verktyg eller information krävs? Ange eventuella begränsningar eller regler.
+- **Leverans** – Vad ska levereras? Ange filformat, repos eller andra konkreta leveranser.
+- **Risker & hinder** – Lista potentiella risker och hinder som kan påverka uppdraget (t.ex. åtkomstproblem, tidsramar).
+
+## Exempel på ifylld mall
+
+- **Syfte/mål:** Sammanställa en konkurrensanalys av tre utvalda konkurrenter inom AI ‑ agenter.
+- **Förutsättningar:** Tillgång till konkurrenternas publika information (webbsidor, bloggar). Ingen inloggning krävs.
+- **Leverans:** En rapport i Google Drive (Markdown) samt en sammanfattning i ett GitHub ‑ issue.
+- **Risker & hinder:** Konkurrenternas information kan vara begränsad; tidsramen är snäv (2 arbetsdagar).
+
+> **Tips:** Använd mallen för varje nytt uppdrag så att alla uppgifter är konsekvent beskrivna och enkla att följa upp.

--- a/docs/qa-checklista.md
+++ b/docs/qa-checklista.md
@@ -1,0 +1,12 @@
+# QA‑checklista för PRs och förändringar
+
+Denna checklista används för att säkerställa att pull requests och andra förändringar håller hög kvalitet och följer våra riktlinjer.
+
+1. **Läs beskrivningen noggrant** – Förstår du syftet med ändringen? Är What/Why/Verify tydligt?
+2. **Inga hemligheter** – Verifiera att inga API‑nycklar, lösenord eller annan känslig information finns i koden eller dokumentationen.
+3. **Dokumentation uppdaterad** – Om ändringen kräver uppdaterad dokumentation, se till att den är inkluderad.
+4. **Testa och bygg** – Om koden påverkas: kör tester och bygg lokalt för att säkerställa att inget bryts.
+5. **Runtime‑påverkan** – För dokumentation‑PRs: dubbelkolla att inga körbara filer eller konfigurationsändringar råkar inkluderas.
+6. **Feedback och förslag** – Lämna konstruktiv feedback. Föreslå förbättringar när det behövs.
+
+> Använd checklistan vid varje PR för att upprätthålla en hög kvalitetsnivå.

--- a/docs/weekly-digest.md
+++ b/docs/weekly-digest.md
@@ -1,0 +1,18 @@
+# Weekly Digest – Mall
+
+Denna veckovisa rapport ger en övergripande bild av vad som har gjorts och vad som planeras. Använd mallen för att kommunicera framsteg och identifiera risker.
+
+## Veckans highlights
+- Kort sammanfattning av de viktigaste resultaten och händelserna under veckan.
+
+## Status på uppgifter
+- **Backlog:** Antal och kort beskrivning av uppgifter som väntar på att startas.
+- **Doing:** Vad pågår just nu? Lista de uppgifter som är i arbete.
+- **Review:** Vilka leveranser väntar på granskning?
+- **Done:** Vilka uppgifter är helt klara denna vecka?
+
+## Risker och åtgärder
+- Identifiera risker som har uppstått eller kan uppstå. Beskriv föreslagna åtgärder eller stöd som behövs.
+
+## Nästa veckas fokus
+- Vilka områden och uppgifter kommer att prioriteras under nästa vecka?


### PR DESCRIPTION
## What
Adds documentation and templates to the repository under `docs/`:
- **mission-control.md** – Kanban board structure with Backlog, Doing, Review, Done columns, WIP rule and definition of done.
- **prompt-mallar.md** – Standard prompt template for assignments with sections for goals, prerequisites, delivery and risks.
- **morning-brief.md** – Morning brief template with date, status, plan, blockers and assistant status.
- **weekly-digest.md** – Weekly digest template with highlights, task status, risks and next week's focus.
- **qa-checklista.md** – QA checklist for pull requests and changes.
- **pr_plan.md** – This pull request plan for reference.

## Why
To establish a stable “Agent‑first” work process with clear templates and documentation. These files support consistent planning, execution and quality assurance.

## Verify
Docs only, no runtime impact. This PR only adds markdown documentation and templates.
