### PR TITLE
Add briefing rules document

### DIFF
--- a/docs/briefing-rules.md
+++ b/docs/briefing-rules.md
@@ -1,0 +1,12 @@
+# Briefing-regler
+
+1. Börja alltid med rubriken och ange titel och datum/vecka.
+2. Inkludera en sektion "Inputs (källor)" där du listar exakt vilka dokument, issues och PR:er som briefen baseras på.
+3. Gör inga gissningar om pågående arbete, kalenderhändelser eller status – använd endast bekräftade fakta.
+4. Om information saknas, skapa en sektion "Behöver från Patrik" med max tre konkreta frågor.
+5. Samla eventuella antaganden i en egen sektion "Antaganden" och håll denna så kort som möjligt.
+6. Strukturera Morning Brief med sektionerna: Inputs, Behöver från Patrik, Antaganden, Lägesrapport, Plan för dagen, Blockerare & hinder, och Assistentens status.
+7. Strukturera Weekly Digest med sektionerna: Inputs, Behöver från Patrik, Antaganden, Veckans highlights, Status per uppgift, Risker & åtgärder, och Nästa veckas fokus.
+8. Använd tydligt och konkret språk utan onödigt fluff eller idiom; håll dig till det väsentliga.
+9. För varje sektion, använd punktlistor för att göra informationen lättläst.
+10. Granska alltid dokumentet innan leverans för att säkerställa att all fakta stämmer och att inga hemligheter eller känsliga uppgifter förekommer.


### PR DESCRIPTION
## What
- Adds `docs/briefing-rules.md` containing 10 regler för hur Morning Briefs och Weekly Digests ska skrivas.

## Why
- Ger ett tydligt regelverk som säkerställer att briefing-dokument är faktabaserade, strukturerade och innehåller minimal mängd antaganden.

## Verify
- Bekräfta att endast dokumentation har lagts till: ingen kod eller konfigurationsändring som påverkar runtime.
- Öppna `docs/briefing-rules.md` och kontrollera att det finns exakt 10 regler enligt specifikationen.
- PR:n gör inga övriga ändringar i projektet (Docs only, no runtime impact).