### PR TITLE
Standardize 'Behöver från Patrik' sections in templates

### DIFF
--- a/docs/morning-brief.md
+++ b/docs/morning-brief.md
@@ -5,7 +5,12 @@ Denna dagliga brief sammanfattar aktuell status och planering. Fyll i varje sekt
 ## Datum
 Skriv aktuellt datum (ÅÅÅÅ‑MM‑DD).
 
-## Lägesrapport
+## Behöver från Patrik
+- Topp 3 prioriteringar (1–3)
+- Hårda deadlines kommande 7 dagar? (ja/nej + datum)
+- Blockerare som stoppar något just nu? (ja/nej + vad)
+
+# Lägesrapport
 - Vad har gjorts sedan senaste briefen? Summera arbetet och eventuella framsteg.
 
 ## Plan för idag

--- a/docs/morning-brief.md
+++ b/docs/morning-brief.md
@@ -1,0 +1,18 @@
+# Morning Brief – Mall
+
+Denna dagliga brief sammanfattar aktuell status och planering. Fyll i varje sektion kortfattat.
+
+## Datum
+Skriv aktuellt datum (ÅÅÅÅ‑MM‑DD).
+
+## Lägesrapport
+- Vad har gjorts sedan senaste briefen? Summera arbetet och eventuella framsteg.
+
+## Plan för idag
+- Vilka uppgifter ska prioriteras under dagen? Lista kort vad som ska göras.
+
+## Blockerare & hinder
+- Finns det något som hindrar arbetet? Behöver du hjälp eller resurser?
+
+## Assistentens status
+- Kort notering från agenten om arbetsbelastning och eventuella behov (t.ex. mer information, extra access).

--- a/docs/pr_plan.md
+++ b/docs/pr_plan.md
@@ -1,0 +1,13 @@
+# PR ‑plan: Dokumentation och mallar
+
+1. **Syfte:** Lägga till dokumentation och mallar för processerna “Mission Control”, standardmallar för uppdrag, Morning Brief, Weekly Digest och QA‑checklista i repositoryt.
+2. **Branch:** Denna PR skapas från en separat dokumentationsbranch (`docs-templates`) för att undvika förändringar i huvudbranschen.
+3. **Filer som inkluderas:**
+   - `docs/mission-control.md` – Kanban struktur med kolumnerna Backlog, Doing, Review, Done samt WIP regler och definition of done.
+   - `docs/prompt-mallar.md` – Standardmall för uppdrag (promptmall) med rubriker för mål, förutsättningar, leverans och risker.
+   - `docs/morning-brief.md` – Mall för daglig morgonbrief med sektioner för datum, lägesrapport, plan, blockerare och assistentens status.
+   - `docs/weekly-digest.md` – Mall för veckovis sammanfattning med highlights, uppgiftsstatus, risker och nästa veckas fokus.
+   - `docs/qa-checklista.md` – QA checklista för pull requests och förändringar.
+   - `docs/pr_plan.md` – Denna plan för PR:n för spårbarhet.
+4. **Commit meddelande:** “Add documentation and templates (Mission Control, prompt mall, Morning Brief, Weekly Digest, QA checklist, PR plan)”
+5. **Pull request:** Skapa en PR mot huvudbranschen och länka till relaterade issues. Inkludera sektionerna What/Why/Verify i beskrivningen. `Verify` ska notera att PR:n endast innehåller dokumentation och inte påverkar runtime.

--- a/docs/prompt-mallar.md
+++ b/docs/prompt-mallar.md
@@ -1,0 +1,19 @@
+# Standardmall för uppdrag (Promptmall)
+
+Denna mall används för att beskriva uppdrag som delegeras till agenten. Anpassa vid behov beroende på uppgiftens natur.
+
+## Rubriker i mallen
+
+- **Syfte/mål** – Vad ska uppnås? Beskriv det önskade resultatet tydligt.
+- **Förutsättningar** – Vilka resurser, verktyg eller information krävs? Ange eventuella begränsningar eller regler.
+- **Leverans** – Vad ska levereras? Ange filformat, repos eller andra konkreta leveranser.
+- **Risker & hinder** – Lista potentiella risker och hinder som kan påverka uppdraget (t.ex. åtkomstproblem, tidsramar).
+
+## Exempel på ifylld mall
+
+- **Syfte/mål:** Sammanställa en konkurrensanalys av tre utvalda konkurrenter inom AI ‑ agenter.
+- **Förutsättningar:** Tillgång till konkurrenternas publika information (webbsidor, bloggar). Ingen inloggning krävs.
+- **Leverans:** En rapport i Google Drive (Markdown) samt en sammanfattning i ett GitHub ‑ issue.
+- **Risker & hinder:** Konkurrenternas information kan vara begränsad; tidsramen är snäv (2 arbetsdagar).
+
+> **Tips:** Använd mallen för varje nytt uppdrag så att alla uppgifter är konsekvent beskrivna och enkla att följa upp.

--- a/docs/qa-checklista.md
+++ b/docs/qa-checklista.md
@@ -1,0 +1,12 @@
+# QA‑checklista för PRs och förändringar
+
+Denna checklista används för att säkerställa att pull requests och andra förändringar håller hög kvalitet och följer våra riktlinjer.
+
+1. **Läs beskrivningen noggrant** – Förstår du syftet med ändringen? Är What/Why/Verify tydligt?
+2. **Inga hemligheter** – Verifiera att inga API‑nycklar, lösenord eller annan känslig information finns i koden eller dokumentationen.
+3. **Dokumentation uppdaterad** – Om ändringen kräver uppdaterad dokumentation, se till att den är inkluderad.
+4. **Testa och bygg** – Om koden påverkas: kör tester och bygg lokalt för att säkerställa att inget bryts.
+5. **Runtime‑påverkan** – För dokumentation‑PRs: dubbelkolla att inga körbara filer eller konfigurationsändringar råkar inkluderas.
+6. **Feedback och förslag** – Lämna konstruktiv feedback. Föreslå förbättringar när det behövs.
+
+> Använd checklistan vid varje PR för att upprätthålla en hög kvalitetsnivå.

--- a/docs/weekly-digest.md
+++ b/docs/weekly-digest.md
@@ -1,5 +1,10 @@
 # Weekly Digest – Mall
 
+
+## Behöver från Patrik
+- Topp 3 prioriteringar (1‑3)
+- Hårda deadlines kommande 7 dagar? (ja/nej + datum)
+- Blockerare som stoppar något just nu? (ja/nej + vad)
 Denna veckovisa rapport ger en övergripande bild av vad som har gjorts och vad som planeras. Använd mallen för att kommunicera framsteg och identifiera risker.
 
 ## Veckans highlights

--- a/docs/weekly-digest.md
+++ b/docs/weekly-digest.md
@@ -1,0 +1,18 @@
+# Weekly Digest – Mall
+
+Denna veckovisa rapport ger en övergripande bild av vad som har gjorts och vad som planeras. Använd mallen för att kommunicera framsteg och identifiera risker.
+
+## Veckans highlights
+- Kort sammanfattning av de viktigaste resultaten och händelserna under veckan.
+
+## Status på uppgifter
+- **Backlog:** Antal och kort beskrivning av uppgifter som väntar på att startas.
+- **Doing:** Vad pågår just nu? Lista de uppgifter som är i arbete.
+- **Review:** Vilka leveranser väntar på granskning?
+- **Done:** Vilka uppgifter är helt klara denna vecka?
+
+## Risker och åtgärder
+- Identifiera risker som har uppstått eller kan uppstå. Beskriv föreslagna åtgärder eller stöd som behövs.
+
+## Nästa veckas fokus
+- Vilka områden och uppgifter kommer att prioriteras under nästa vecka?

--- a/docs/weekly-digest.md
+++ b/docs/weekly-digest.md
@@ -5,6 +5,7 @@
 - Topp 3 prioriteringar (1‑3)
 - Hårda deadlines kommande 7 dagar? (ja/nej + datum)
 - Blockerare som stoppar något just nu? (ja/nej + vad)
+
 Denna veckovisa rapport ger en övergripande bild av vad som har gjorts och vad som planeras. Använd mallen för att kommunicera framsteg och identifiera risker.
 
 ## Veckans highlights


### PR DESCRIPTION
## What
- Updates `docs/morning-brief.md` and `docs/weekly-digest.md` to include a standardized **Behöver från Patrik** section.
- The section now asks exactly three questions: topp 3 prioriteringar, hårda deadlines kommande 7 dagar (ja/nej + datum) och blockerare som stoppar något just nu (ja/nej + vad).

## Why
- Ensures that briefs and digests consistently request the key inputs from Patrik, reducing ambiguity and speculation.
- Aligns with updated briefing rules and process improvements.

## Verify
- Confirm that only markdown documentation files are changed: `morning-brief.md` and `weekly-digest.md` in the `docs` folder.
- Check the **Behöver från Patrik** section in both files to ensure it contains exactly the three specified questions.
- No code or runtime configuration changes are included (Docs only, no runtime impact).
